### PR TITLE
feat: add config property to --disable-encryption

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ description: 'Setup a dfx environment and add it to the PATH.'
 inputs:
   dfx-version:
     description: 'The dfx version to download.'
+  dfx-disable-encryption:
+    description: 'Wether to use the .pem encryption'
+    default: false
   install-moc:
     description: 'Whether to install moc through dfx.'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,8 +50,9 @@ function run() {
             return;
         }
         const dfxVersion = core.getInput('dfx-version');
+        const dfxDisableEncryption = core.getInput('dfx-disable-encryption');
         if (dfxVersion) {
-            core.info(`Setup dfx version ${dfxVersion}`);
+            core.info(`Setup dfx version ${dfxVersion}${dfxDisableEncryption ? ' (without encryption)' : ''}`);
             // Opt-out of having data collected about dfx usage.
             core.exportVariable('DFX_TELEMETRY_DISABLED', 1);
             // Install dfx.
@@ -64,7 +65,7 @@ function run() {
             // Setup identity.
             const id = process.env[`DFX_IDENTITY_PEM`] || '';
             if (id) {
-                child_process_1.default.execSync(`${dfxPath} identity new action`);
+                child_process_1.default.execSync(`${dfxPath} identity new action${dfxDisableEncryption ? ' --disable-encryption' : ''}`);
                 child_process_1.default.execSync(`chmod +w /home/runner/.config/dfx/identity/action/identity.pem`);
                 child_process_1.default.execSync(`echo "${id}" > /home/runner/.config/dfx/identity/action/identity.pem`);
                 infoExec(`${dfxPath} identity list`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,9 @@ export async function run() {
     }
 
     const dfxVersion = core.getInput('dfx-version');
+    const dfxDisableEncryption = core.getInput('dfx-disable-encryption');
     if (dfxVersion) {
-        core.info(`Setup dfx version ${dfxVersion}`);
+        core.info(`Setup dfx version ${dfxVersion}${dfxDisableEncryption ? ' (without encryption)' : ''}`);
 
         // Opt-out of having data collected about dfx usage.
         core.exportVariable('DFX_TELEMETRY_DISABLED', 1);
@@ -28,7 +29,7 @@ export async function run() {
         // Setup identity.
         const id: string = process.env[`DFX_IDENTITY_PEM`] || '';
         if (id) {
-            cp.execSync(`${dfxPath} identity new action`);
+            cp.execSync(`${dfxPath} identity new action${dfxDisableEncryption ? ' --disable-encryption' : ''}`);
             cp.execSync(`chmod +w /home/runner/.config/dfx/identity/action/identity.pem`)
             cp.execSync(`echo "${id}" > /home/runner/.config/dfx/identity/action/identity.pem`);
             infoExec(`${dfxPath} identity list`);


### PR DESCRIPTION

## Proposed Changes

Allow `--disable-encryption` when creating the identity. This prevents password prompt when using the `action` identity.

Ref: https://internetcomputer.org/docs/current/references/cli-reference/dfx-identity/#options