### PR TITLE
DO NOT MERGE: Now that dfxvm has launched, update to install with the auto initialize environment variable set

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ export async function run() {
         core.exportVariable('DFX_TELEMETRY_DISABLED', 1);
 
         // Install dfx.
-        cp.execSync(`echo y | DFX_VERSION=${dfxVersion} sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"`);
+        cp.execSync(`echo y | DFXVM_INIT_YES=true DFX_VERSION=${dfxVersion} sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"`);
 
         const dfxPath = await io.which('dfx');
         core.debug(dfxPath);


### PR DESCRIPTION
Fixes #

## Proposed Changes

Currently, when installing one receives the following error:

```
Error: Command failed: echo y | DFX_VERSION=0.16.1 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
sh: 0: can't access tty; job control turned off
Executing dfxvm install script, commit: 27df5b45eb80772f643cfce1ef78797c511920b4
Downloading latest release...
Checking integrity of tarball...
error: failed to interact with console
error:     caused by: IO error: not a terminal
error:     caused by: not a terminal
...
```
